### PR TITLE
Fix for Firefox 44 and greater

### DIFF
--- a/index.js
+++ b/index.js
@@ -3,11 +3,11 @@
 module.exports = function getBrowserRTC () {
   if (typeof window === 'undefined') return null
   var wrtc = {
-    RTCPeerConnection: window.mozRTCPeerConnection || window.RTCPeerConnection ||
+    RTCPeerConnection: window.RTCPeerConnection || window.mozRTCPeerConnection ||
       window.webkitRTCPeerConnection,
-    RTCSessionDescription: window.mozRTCSessionDescription ||
-      window.RTCSessionDescription || window.webkitRTCSessionDescription,
-    RTCIceCandidate: window.mozRTCIceCandidate || window.RTCIceCandidate ||
+    RTCSessionDescription: window.RTCSessionDescription ||
+      window.mozRTCSessionDescription || window.webkitRTCSessionDescription,
+    RTCIceCandidate: window.RTCIceCandidate || window.mozRTCIceCandidate ||
       window.webkitRTCIceCandidate
   }
   if (!wrtc.RTCPeerConnection) return null


### PR DESCRIPTION
Firefox is showing this deprecation warning:

“WebRTC interfaces with the "moz" prefix (mozRTCPeerConnection,
mozRTCSessionDescription, mozRTCIceCandidate) have been deprecated.”