### PR TITLE
Legacy browser support (Microsoft Edge)

### DIFF
--- a/index.js
+++ b/index.js
@@ -1,14 +1,15 @@
 // originally pulled out of simple-peer
 
 module.exports = function getBrowserRTC () {
-  if (typeof globalThis === 'undefined') return null
+  let GLOBAL;
+  if (typeof globalThis !== 'undefined') GLOBAL = globalThis
+  else if (typeof window !== 'undefined') GLOBAL = window
+  else if (typeof global !== 'undefined') GLOBAL = global
+  else return null;
   var wrtc = {
-    RTCPeerConnection: globalThis.RTCPeerConnection || globalThis.mozRTCPeerConnection ||
-      globalThis.webkitRTCPeerConnection,
-    RTCSessionDescription: globalThis.RTCSessionDescription ||
-      globalThis.mozRTCSessionDescription || globalThis.webkitRTCSessionDescription,
-    RTCIceCandidate: globalThis.RTCIceCandidate || globalThis.mozRTCIceCandidate ||
-      globalThis.webkitRTCIceCandidate
+    RTCPeerConnection: GLOBAL.RTCPeerConnection || GLOBAL.mozRTCPeerConnection || GLOBAL.webkitRTCPeerConnection,
+    RTCSessionDescription: GLOBAL.RTCSessionDescription || GLOBAL.mozRTCSessionDescription || GLOBAL.webkitRTCSessionDescription,
+    RTCIceCandidate: GLOBAL.RTCIceCandidate || GLOBAL.mozRTCIceCandidate || GLOBAL.webkitRTCIceCandidate
   }
   if (!wrtc.RTCPeerConnection) return null
   return wrtc


### PR DESCRIPTION
I have run into a problem working with windows dot-net web container, which is Microsoft Edge 12 based. `globalThis` is not supported in this browser and updating a dependency introduced latest `get-browser-rtc` into our project, making it fail to connect.

This fix should run a short "fallback cycle" from globalThis to window to global (for nodejs) and then fail if none exists.